### PR TITLE
[QPSolver] Adapt to abstract QP solver, support Tasks

### DIFF
--- a/src/constraints/BoundedAccelerationConstr.h
+++ b/src/constraints/BoundedAccelerationConstr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mc_solver/GenInequalityConstraint.h>
+#include <mc_solver/ConstraintSet.h>
 
 namespace details
 {
@@ -42,12 +43,12 @@ struct BoundedAccelerationConstr : public mc_solver::ConstraintSet
 {
   BoundedAccelerationConstr(unsigned int rIndex, double maxAccTransXY, double maxAccRotZ);
 
-  void addToSolver(const std::vector<rbd::MultiBody> & mbs, tasks::qp::QPSolver & solver) override;
-
-  void removeFromSolver(tasks::qp::QPSolver & solver) override;
+ protected:
+  void addToSolverImpl(mc_solver::QPSolver & solver) override;
+  virtual void removeFromSolverImpl(mc_solver::QPSolver & solver) override;
 private:
   details::BoundedAccelerationConstr constr_;
-  bool inSolver_ = false;
+  unsigned rIndex_ = 0;
 };
 
 } // namespace mc_pepper

--- a/src/tasks/CoMRelativeBodyTask.h
+++ b/src/tasks/CoMRelativeBodyTask.h
@@ -73,10 +73,10 @@ namespace mc_pepper
 {
 /** Now that we have a tasks::qp::HighLevelTask we can wrap it in mc_rtc's
  * generic TrajectoryTask wrapper */
-struct CoMRelativeBodyTask : public mc_tasks::TrajectoryTaskGeneric<details::CoMRelativeBodyTask>
+struct CoMRelativeBodyTask : public mc_tasks::TrajectoryTaskGeneric
 {
   // Shortcut name for the base class
-  using Base = mc_tasks::TrajectoryTaskGeneric<details::CoMRelativeBodyTask>;
+  using Base = mc_tasks::TrajectoryTaskGeneric;
 
   CoMRelativeBodyTask(const std::string & body, const mc_rbdyn::Robots & robots, unsigned int robotIndex, double stiffness, double weight);
 
@@ -86,6 +86,10 @@ struct CoMRelativeBodyTask : public mc_tasks::TrajectoryTaskGeneric<details::CoM
 
   const Eigen::Vector3d & target() const;
 
+  const Eigen::Vector3d actual() const;
+
+  const Eigen::Vector3d & bodyPosW() const;
+
   void reset() override;
 
   void addToLogger(mc_rtc::Logger & logger) override;
@@ -93,6 +97,10 @@ struct CoMRelativeBodyTask : public mc_tasks::TrajectoryTaskGeneric<details::CoM
   void addToGUI(mc_rtc::gui::StateBuilder &) override;
 
   void removeFromLogger(mc_rtc::Logger & logger) override;
+
+ protected:
+  std::string body_ = "";
+  unsigned bIndex_ = 0;
 };
 
 } // namespace mc_pepper


### PR DESCRIPTION
Adapts to the changes introduced by https://github.com/jrl-umi3218/mc_rtc/pull/254
This only implements `Tasks` support, `TVM` support shall come at a later stage.